### PR TITLE
Set initial target value

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ var ReactGauge = function (_React$Component) {
     key: 'componentDidMount',
     value: function componentDidMount() {
       this.gauge = new _gaugeAnimated2.default(this.div, this.props);
+      this.gauge.setTarget(this.props.value);
     }
   }, {
     key: 'shouldComponentUpdate',


### PR DESCRIPTION
`setTarget` is only called in `componentDidUpdate`, so something like this:

```
ReactDOM.render(<ReactGauge value={100}>, element);
```

will only show 0.

This PR adds `setTarget` call to `componentDidMount`, so that initial value is set correctly.


BTW It seems that only compiled version of index.js is available in this repo. Is that on purpose?